### PR TITLE
Fix auto deployment

### DIFF
--- a/.github/workflows/rails-tests.yml
+++ b/.github/workflows/rails-tests.yml
@@ -87,17 +87,3 @@ jobs:
       run: |
         cd backend
         bundle exec rake test
-
-  deploy:
-    runs-on: ubuntu-latest
-    needs: test
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    steps:
-      - uses: actions/checkout@v2
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: 3.2.2
-      - name: Deploy to Render
-        run: |
-          curl -fsSL https://render.com/deploy/github-actions.sh | bash

--- a/.github/workflows/rails-tests.yml
+++ b/.github/workflows/rails-tests.yml
@@ -91,7 +91,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     needs: test
-    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged)
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v2
       - name: Set up Ruby

--- a/.github/workflows/rails-tests.yml
+++ b/.github/workflows/rails-tests.yml
@@ -91,6 +91,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     needs: test
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged)
     steps:
       - uses: actions/checkout@v2
       - name: Set up Ruby

--- a/.github/workflows/rails-tests.yml
+++ b/.github/workflows/rails-tests.yml
@@ -91,7 +91,6 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     needs: test
-    if: github.event_name == 'push'
     steps:
       - uses: actions/checkout@v2
       - name: Set up Ruby


### PR DESCRIPTION
### Summary:
- Removed the deploy step from the GitHub Actions workflow.
- Deployment will now be handled manually or through Render’s auto-deploy on `main` branch pushes.

### Next Steps:
- Trigger deployment manually via the Render dashboard or configure auto-deploy on `main`.
